### PR TITLE
fix(*): set revealed content to fill max width

### DIFF
--- a/revealswipe/src/main/java/de/charlex/compose/RevealSwipe.kt
+++ b/revealswipe/src/main/java/de/charlex/compose/RevealSwipe.kt
@@ -216,30 +216,36 @@ fun RevealSwipe(
                 horizontalArrangement = Arrangement.End,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth(0.5f)
-                        .fillMaxHeight()
-                        .background(if (state.directions.contains(RevealDirection.StartToEnd)) animatedBackgroundStartColor else Color.Transparent)
-                        .clickable(onClick = {
-                            backgroundStartClick()
-                        }),
-                    horizontalArrangement = Arrangement.Start,
-                    verticalAlignment = Alignment.CenterVertically,
-                    content = hiddenContentStart
-                )
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth(1f)
-                        .fillMaxHeight()
-                        .background(if (state.directions.contains(RevealDirection.EndToStart)) animatedBackgroundEndColor else Color.Transparent)
-                        .clickable(onClick = {
-                            backgroundEndClick()
-                        }),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically,
-                    content = hiddenContentEnd
-                )
+                val hasStartContent = state.directions.contains(RevealDirection.StartToEnd)
+                val hasEndContent = state.directions.contains(RevealDirection.EndToStart)
+                if (hasStartContent) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth(if (hasEndContent) 0.5f else 1F)
+                            .fillMaxHeight()
+                            .background(animatedBackgroundStartColor)
+                            .clickable(onClick = {
+                                backgroundStartClick()
+                            }),
+                        horizontalArrangement = Arrangement.Start,
+                        verticalAlignment = Alignment.CenterVertically,
+                        content = hiddenContentStart
+                    )
+                }
+                if (hasEndContent) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .fillMaxHeight()
+                            .background(animatedBackgroundEndColor)
+                            .clickable(onClick = {
+                                backgroundEndClick()
+                            }),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically,
+                        content = hiddenContentEnd
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
### Use Case
If you have hidden content that takes up wider than 50% of the container, when swiping open the content is cut off at the 50% point.

### Solution
The width of the start and end content is set to either 100% or 50% depending on the swipe directions provided in the state class.
